### PR TITLE
refactor(serializers): add base serializer to extend general implementation

### DIFF
--- a/app/controllers/api/v1/properties_controller.rb
+++ b/app/controllers/api/v1/properties_controller.rb
@@ -1,10 +1,10 @@
 class Api::V1::PropertiesController < Api::V1::BaseController
   def index
-    respond_with paginate(filtered_collection(Property.all))
+    respond_with paginate(filtered_collection(Property.all)), deep: params[:deep].present?
   end
 
   def show
-    respond_with property
+    respond_with property, deep: params[:deep].present?
   end
 
   def create
@@ -12,7 +12,7 @@ class Api::V1::PropertiesController < Api::V1::BaseController
   end
 
   def update
-    respond_with property.update!(property_params)
+    respond_with property.update!(property_params), deep: params[:deep].present?
   end
 
   def destroy

--- a/app/serializers/api/v1/geopoint_serializer.rb
+++ b/app/serializers/api/v1/geopoint_serializer.rb
@@ -1,4 +1,4 @@
-class Api::V1::GeopointSerializer < ActiveModel::Serializer
+class Api::V1::GeopointSerializer < BaseSerializer
   type :geopoint
 
   attributes(
@@ -6,4 +6,6 @@ class Api::V1::GeopointSerializer < ActiveModel::Serializer
     :longitude,
     :property_id
   )
+
+  attribute :property_id, unless: :with_parent?
 end

--- a/app/serializers/api/v1/property_serializer.rb
+++ b/app/serializers/api/v1/property_serializer.rb
@@ -1,4 +1,4 @@
-class Api::V1::PropertySerializer < ActiveModel::Serializer
+class Api::V1::PropertySerializer < BaseSerializer
   type :property
 
   attributes(
@@ -7,8 +7,23 @@ class Api::V1::PropertySerializer < ActiveModel::Serializer
     :description,
     :price,
     :size,
-    :address,
-    :geopoints,
-    :property_services
+    :address
   )
+
+  attribute :geopoints, if: :deep?
+  attribute :property_services, if: :deep?
+
+  def geopoints
+    object.geopoints.map do |geopoint|
+      serializer = Api::V1::GeopointSerializer.new(geopoint, with_parent: true)
+      puts_association(serializer)
+    end
+  end
+
+  def property_services
+    object.property_services.map do |property_service|
+      serializer = Api::V1::PropertyServiceSerializer.new(property_service, with_parent: true)
+      puts_association(serializer)
+    end
+  end
 end

--- a/app/serializers/api/v1/property_service_serializer.rb
+++ b/app/serializers/api/v1/property_service_serializer.rb
@@ -1,8 +1,10 @@
-class Api::V1::PropertyServiceSerializer < ActiveModel::Serializer
+class Api::V1::PropertyServiceSerializer < BaseSerializer
   type :property_service
 
   attributes(
     :name,
     :description
   )
+
+  attribute :property_id, unless: :with_parent?
 end

--- a/app/serializers/base_serializer.rb
+++ b/app/serializers/base_serializer.rb
@@ -1,0 +1,19 @@
+class BaseSerializer < ActiveModel::Serializer
+  def deep?
+    @instance_options[:deep]
+  end
+
+  def with_parent?
+    @instance_options[:with_parent]
+  end
+
+  private
+
+  def puts_association(serializer)
+    {
+      id: serializer.object.id.to_s,
+      type: serializer._type,
+      attributes: serializer.attributes
+    }
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,9 +1,14 @@
-class UserSerializer < ActiveModel::Serializer
+class UserSerializer < BaseSerializer
+  attributes(
+    :id,
+    :name,
+    :last_name,
+    :email
+  )
+
+  attribute :generate_jwt, if: :with_token?
+
   def with_token?
     @instance_options[:with_token]
   end
-
-  attributes :id, :name, :last_name, :email
-
-  attribute :generate_jwt, if: :with_token?
 end


### PR DESCRIPTION
En este PR se implementa un refactor a los serializers para tener una estructura más clara y ordenada.

1. Se implementa un base serializer que entrega los métodos ```deep?``` y ```with_parent?``` para dar distintas opciones de visualización. Además se cambia la herencia de los demás serializers a este.
2. Se agrega a los serializers anidados dentro de otros recursos el atributo condicional de su _parent_id_ para que no sea entregado en caso de venir anidado dentro de su padre.
3. Se implementan los atributos ```geopoints``` y ```property_services``` al serializer de properties. Esta lógica debería implementarse en cualquier otro recurso que tenga recursos anidados. Para asegurar el uso correcto de los serializers en los recursos anidados.
4. Se agrega el chequeo del parámetro ```deep``` para los métodos ```index```, ```show``` y ```update``` de property, de esta forma se puede seleccionar si se desea entregar la información de los recursos anidados o no.