### PR TITLE
fix(property-reference): fix AddUserToPropery migration

### DIFF
--- a/db/migrate/20210427042803_add_user_to_properties.rb
+++ b/db/migrate/20210427042803_add_user_to_properties.rb
@@ -1,5 +1,7 @@
 class AddUserToProperties < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
   def change
-    add_reference :properties, :user, null: false, foreign_key: true
+    add_reference :properties, :user, null: false, index: {algorithm: :concurrently}
   end
 end

--- a/db/migrate/20210504173925_add_foreign_key_on_properties.rb
+++ b/db/migrate/20210504173925_add_foreign_key_on_properties.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyOnProperties < ActiveRecord::Migration[6.0]
+  def change
+    add_foreign_key :properties, :users, validate: false
+  end
+end

--- a/db/migrate/20210504174053_validate_foreign_key_on_properties.rb
+++ b/db/migrate/20210504174053_validate_foreign_key_on_properties.rb
@@ -1,0 +1,5 @@
+class ValidateForeignKeyOnProperties < ActiveRecord::Migration[6.0]
+  def change
+    validate_foreign_key :properties, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_27_042803) do
+ActiveRecord::Schema.define(version: 2021_05_04_174053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
En este PR reestructuro la migración en la que se añade la referencia de usuario al modelo de property para que no genere problemas la gema **StrongMigrations**. Seguí su [documentación](https://github.com/ankane/strong_migrations#adding-a-reference) para separar la migración en varias partes con tal de obtener el mismo resultado

IMPORTANTE
hay que deshacer el último commit hecho (```rails db:rollback STEP=1```) o botar y rehacer la bdd para que los cambios implementados funcionen