### PR TITLE
fix(authentication): skip auth on api's get methods

### DIFF
--- a/app/controllers/api/v1/geopoints_controller.rb
+++ b/app/controllers/api/v1/geopoints_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::GeopointsController < Api::V1::BaseController
+  skip_before_action :authenticate_user!, only: [:index, :show]
+
   def index
     @geopoints = property.geopoints
     respond_with paginate(filtered_collection(@geopoints))

--- a/app/controllers/api/v1/properties_controller.rb
+++ b/app/controllers/api/v1/properties_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::PropertiesController < Api::V1::BaseController
+  skip_before_action :authenticate_user!, only: [:index, :show]
+
   def index
     properties = if params[:commune].present?
                    Property.where(commune: [params[:commune].split(",")])

--- a/app/controllers/api/v1/property_services_controller.rb
+++ b/app/controllers/api/v1/property_services_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::PropertyServicesController < Api::V1::BaseController
+  skip_before_action :authenticate_user!, only: [:index, :show]
+
   def index
     @services = property.property_services
     respond_with paginate(filtered_collection(@services))


### PR DESCRIPTION
Este pr responde la issue #8 de Mobile needs. Se quita la necesidad de autorización para todos los métodos GET (index y show de properties, geopoints y property_services)