### PR TITLE
feat(filter-properties): filter by commune on property's index

### DIFF
--- a/app/controllers/api/v1/properties_controller.rb
+++ b/app/controllers/api/v1/properties_controller.rb
@@ -1,6 +1,11 @@
 class Api::V1::PropertiesController < Api::V1::BaseController
   def index
-    respond_with paginate(filtered_collection(Property.all)), deep: params[:deep].present?
+    properties = if params[:commune].present?
+                   Property.where(commune: [params[:commune].split(",")])
+                 else
+                   Property.all
+                 end
+    respond_with paginate(filtered_collection(properties)), deep: params[:deep].present?
   end
 
   def show


### PR DESCRIPTION
En este PR se responde #10 de mobile needs. Se agrega filtro por comuna para el método index de properties. Este filtro toma el parémetro de url ```commune``` y puede filtrar por múltiples comunas separadas por coma. Por ejemplo:
``` ruby
# GET /api/v1/properties returns
Property.all

# GET /api/v1/properties?commune=Santiago returns
Property.where(commune: "Santiago")

# GET /api/v1/properties?commune=Santiago,Quillota returns
Property.where(commune: ["Santiago", "Quillota"]) # acts as an OR

```