### PR TITLE
fix(serializers): add owner to property serializer

### DIFF
--- a/app/serializers/api/v1/property_serializer.rb
+++ b/app/serializers/api/v1/property_serializer.rb
@@ -5,6 +5,7 @@ class Api::V1::PropertySerializer < BaseSerializer
     :name,
     :commune,
     :description,
+    :owner,
     :price,
     :size,
     :address
@@ -25,5 +26,9 @@ class Api::V1::PropertySerializer < BaseSerializer
       serializer = Api::V1::PropertyServiceSerializer.new(property_service, with_parent: true)
       puts_association(serializer)
     end
+  end
+
+  def owner
+    puts_association(UserSerializer.new(object.user))
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,6 @@
 class UserSerializer < BaseSerializer
+  type :user
+
   attributes(
     :id,
     :name,


### PR DESCRIPTION
En este PR se responde al mobile need #9. Se le agrega ```owner``` al serializer de property. 

Este es el resultado de hacer un llamado GET a ```/api/v1/properties/2?deep=true```. Ps: si el parámetro ```deep``` no se incluye, no se incluyen los atributos de geopoints o propery_services.

![image](https://user-images.githubusercontent.com/30667977/117554545-566a8780-b026-11eb-9490-61168ae1f5d1.png)
