### PR TITLE
Feature: added units to size and price

### DIFF
--- a/app/admin/properties.rb
+++ b/app/admin/properties.rb
@@ -1,12 +1,25 @@
 ActiveAdmin.register Property do
-  permit_params :name, :commune, :description, :active, :price, :size, :address, :user_id
+  permit_params(
+    :name,
+    :commune,
+    :description,
+    :active,
+    :price,
+    :size,
+    :address,
+    :user_id,
+    :price_unit,
+    :size_unit
+  )
 
   filter :name
   filter :commune
   filter :active
   filter :user
   filter :price
+  filter :price_unit
   filter :size
+  filter :size_unit
   filter :created_at
   filter :updated_at
 
@@ -18,7 +31,9 @@ ActiveAdmin.register Property do
     column :user
     column :description
     column :price
+    column :price_unit
     column :size
+    column :size_unit
     column :address
     column :active
     actions

--- a/app/controllers/api/v1/properties_controller.rb
+++ b/app/controllers/api/v1/properties_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::PropertiesController < Api::V1::BaseController
   end
 
   def create
-    respond_with Property.create!(property_params)
+    respond_with current_user.properties.create!(property_params)
   end
 
   def update
@@ -39,9 +39,10 @@ class Api::V1::PropertiesController < Api::V1::BaseController
       :description,
       :active,
       :price,
+      :price_unit,
       :size,
-      :address,
-      :user_id
+      :size_unit,
+      :address
     )
   end
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,4 +1,7 @@
 class Property < ApplicationRecord
+  enum size_unit: { meters: 0, hectare: 1 }
+  enum price_unit: { uf: 0, clp: 1 }
+
   has_many :geopoints, inverse_of: :property
   has_many :property_services, inverse_of: :property
   has_many_attached :images
@@ -26,6 +29,8 @@ end
 #  size        :float
 #  address     :text
 #  user_id     :bigint(8)        not null
+#  size_unit   :integer
+#  price_unit  :integer
 #
 # Indexes
 #

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -10,8 +10,11 @@ class Property < ApplicationRecord
 
   validates :name, presence: true
   validates :commune, presence: true
+
   validates :price, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :price_unit, inclusion: { in: :price_unit }
   validates :size, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :size_unit, inclusion: { in: :size_unit }
 end
 
 # == Schema Information

--- a/app/serializers/api/v1/property_serializer.rb
+++ b/app/serializers/api/v1/property_serializer.rb
@@ -9,10 +9,10 @@ class Api::V1::PropertySerializer < BaseSerializer
     :address
   )
 
-  attribute :geopoints, if: :deep?
-  attribute :property_services, if: :deep?
   attribute :size
   attribute :price
+  attribute :geopoints, if: :deep?
+  attribute :property_services, if: :deep?
 
   def size
     { value: object.size, unit: object.size_unit }

--- a/app/serializers/api/v1/property_serializer.rb
+++ b/app/serializers/api/v1/property_serializer.rb
@@ -6,13 +6,21 @@ class Api::V1::PropertySerializer < BaseSerializer
     :commune,
     :description,
     :owner,
-    :price,
-    :size,
     :address
   )
 
   attribute :geopoints, if: :deep?
   attribute :property_services, if: :deep?
+  attribute :size
+  attribute :price
+
+  def size
+    { value: object.size, unit: object.size_unit }
+  end
+
+  def price
+    { value: object.price, unit: object.price_unit }
+  end
 
   def geopoints
     object.geopoints.map do |geopoint|

--- a/db/migrate/20210508232636_ad_units_to_property_properties.rb
+++ b/db/migrate/20210508232636_ad_units_to_property_properties.rb
@@ -1,0 +1,6 @@
+class AdUnitsToPropertyProperties < ActiveRecord::Migration[6.0]
+  def change
+    add_column :properties, :size_unit, :integer, default: 0
+    add_column :properties, :price_unit, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_04_174053) do
+ActiveRecord::Schema.define(version: 2021_05_08_232636) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,8 @@ ActiveRecord::Schema.define(version: 2021_05_04_174053) do
     t.float "size"
     t.text "address"
     t.bigint "user_id", null: false
+    t.integer "size_unit", default: 0
+    t.integer "price_unit", default: 0
     t.index ["user_id"], name: "index_properties_on_user_id"
   end
 

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -87,14 +87,34 @@
               "x-nullable": true
             },
             "price": {
-              "type": "float",
-              "example": "10000",
-              "x-nullable": true
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "float",
+                  "example": 1000,
+                  "x-nullable": false
+                },
+                "unit": {
+                  "type": "string",
+                  "example": "uf",
+                  "x-nullable": false
+                }
+              }
             },
             "size": {
-              "type": "float",
-              "example": "1000",
-              "x-nullable": true
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "float",
+                  "example": 1000,
+                  "x-nullable": false
+                },
+                "unit": {
+                  "type": "string",
+                  "example": "meters",
+                  "x-nullable": false
+                }
+              }
             },
             "address": {
               "type": "string",


### PR DESCRIPTION
En este PR se resuelve #11 , agregando las unidades respectivas para los los tamaños y los precios.

El esquema de respuesta es el siguiente ahora:

```json
{
    "data": [
        {
            "id": "1",
            "type": "property",
            "attributes": {
                "name": "Mi casa",
                "commune": "Las Condes",
                "description": null,
                "owner": {
                    "id": "1",
                    "type": "user",
                    "attributes": {
                        "id": 1,
                        "name": "Rodrigo",
                        "last_name": "Hanuch",
                        "email": "rihanuch@uc.cl"
                    }
                },
                "address": "Mi casa 123",
                "size": {
                    "value": 10.0,
                    "unit": "meters"
                },
                "price": {
                    "value": 100.0,
                    "unit": "uf"
                }
            }
        }
    ],
    "links": {
        "self": "http://localhost:3000/api/v1/properties?page%5Bnumber%5D=1&page%5Bsize%5D=25",
        "first": "http://localhost:3000/api/v1/properties?page%5Bnumber%5D=1&page%5Bsize%5D=25",
        "prev": null,
        "next": null,
        "last": "http://localhost:3000/api/v1/properties?page%5Bnumber%5D=1&page%5Bsize%5D=25"
    }
}
```

Por otro lado, el `POST` para las unidades tiene que venir como `size_unit` o `price_unit` sin anidación (como se ve a continuación)

![Screen Shot 2021-05-08 at 20 49 53](https://user-images.githubusercontent.com/26392931/117557263-28457180-b03f-11eb-8a92-db655a9b9d8f.png)

Las unidades por defecto son `uf` y `meters`, con la opción de poner `hectare` o `clp`