### PR TITLE
fix(cors): add middleware to allow all origins and actions

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,5 +10,11 @@ module Phpeople
     config.active_job.queue_adapter = :sidekiq
     config.assets.paths << Rails.root.join('node_modules')
     config.load_defaults 6.0
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', headers: :any, methods: [:get, :post, :put, :patch, :delete, :options]
+      end
+    end
   end
 end


### PR DESCRIPTION
Se agrega un middleware con rack-cors para aceptar requests desde cualquier origen y permitir requests desde los frontends.

Se siguió [este tutorial](https://medium.com/@Nicholson85/handling-cors-issues-in-your-rails-api-120dfbcb8a24) para implementar el middleware.